### PR TITLE
Checking for XML-RPC library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ configure_file(
   )
 
 # bring dependent projects
+find_package(XMLRPC REQUIRED c++)
 find_package(PCL 1.7.1 REQUIRED COMPONENTS common visualization filters)
 find_package(OpenCV REQUIRED)
 
@@ -42,11 +43,13 @@ find_package(OpenCV REQUIRED)
 include_directories(
   ${O3D3XX_BINARY_DIR}/include
   ${PCL_INCLUDE_DIRS}
+  ${XMLRPC_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
   )
 link_directories(
   ${O3D3XX_BINARY_DIR}/lib
   ${PCL_LIBRARY_DIRS}
+  ${XMLRPC_LIBRARIES}
   ${OpenCV_LIBRARY_DIRS}
   )
 add_definitions(


### PR DESCRIPTION
This adds a cmake check if the libxmlrpc-c library and its c++ wrapper is
installed.

My cmake knowledge is a bit rusty so this may need some polishing....

Signed-off-by: Christian Ege <k4230r6@gmail.com>