### PR TITLE
Add parens to avoid unexpected evaluation order behavior

### DIFF
--- a/src/libo3d3xx/image.cpp
+++ b/src/libo3d3xx/image.cpp
@@ -342,7 +342,7 @@ o3d3xx::ImageBuffer::Organize()
         }
 
       conf_row_ptr[col] = this->bytes_.at(cidx);
-      if (conf_row_ptr[col] & 0x1 == 1)
+      if ((conf_row_ptr[col] & 0x1) == 1)
         {
           pt.x = pt.y = pt.z = bad_point;
           this->cloud_->is_dense = false;


### PR DESCRIPTION
& has lower precedence than ==, so the expression is not evaluated as expected.