### PR TITLE
Create an option to initialize a senor with a camera application

### DIFF
--- a/src/bin/o3d3xx-reset.cpp
+++ b/src/bin/o3d3xx-reset.cpp
@@ -39,8 +39,13 @@ int main(int argc, const char** argv)
 
       po::options_description reset_opts("Reset Information");
       reset_opts.add_options()
-        ("reboot", "Reboot the sensor after reset");
+        ("reboot", "Reboot the device after reset (ATTENTION: The network configuration may change)");
       opts.visible.add(reset_opts);
+
+      po::options_description sensor_opts("Sensor Information");
+      sensor_opts.add_options()
+        ("sensor", "Create a new default \"camera\" application for a \"sensor\" device");
+      opts.visible.add(sensor_opts);
 
       if (! opts.Parse(argc, argv, &camera_ip, &xmlrpc_port, &password))
         {
@@ -55,7 +60,37 @@ int main(int argc, const char** argv)
 
       cam->RequestSession();
       cam->SetOperatingMode(o3d3xx::Camera::operating_mode::EDIT);
-      cam->FactoryReset();
+      if (opts.vm.count("sensor"))
+        {
+          // create a new application
+          int app_idx = cam->CreateApplication();
+          cam->EditApplication(app_idx);
+          o3d3xx::ImagerConfig::Ptr imager = cam->GetImagerConfig();
+
+          // Set values which comply with the default "camera" application
+          imager->SetType("upto30m_low");
+          imager->SetEnableRectificationAmplitudeImage(false);
+          imager->SetEnableRectificationDistanceImage(false);
+          imager->SetExposureTime(5000);
+          imager->SetExposureTimeList("5000");
+          imager->SetFrameRate(10.0);
+          cam->SetImagerConfig(imager.get());
+          cam->SaveApp();
+          cam->StopEditingApplication();
+
+          // activate the created application
+          o3d3xx::DeviceConfig::Ptr dev = cam->GetDeviceConfig();
+          dev->SetActiveApplication(app_idx);
+          cam->SetDeviceConfig(dev.get());
+          cam->SaveDevice();
+          cam->CancelSession();
+        }
+      else
+        {
+          cam->FactoryReset();
+        }
+
+      cam->CancelSession();
 
       if (opts.vm.count("reboot"))
         {


### PR DESCRIPTION
At the moment ifm sells two types of O3D3XX devices a so called camera
with a 5 PIN connector and a sensor with a 8 PIN connector. Both devices
are API compatible but the sensor lacks a default application in factory
default mode.

This patch provides a command line option to create and activate a default
camera application.

Maybe @cfreundl can check if I missed something 

Signed-off-by: Christian Ege <k4230r6@gmail.com>