### PR TITLE
Added required prefixes for parameters that can be changed temporarily

### DIFF
--- a/modules/camera/src/libo3d3xx_camera/camera.cpp
+++ b/modules/camera/src/libo3d3xx_camera/camera.cpp
@@ -275,8 +275,9 @@ o3d3xx::Camera::SetTemporaryApplicationParameters(
     {
       std::pair<std::string, xmlrpc_c::value> member;
 
-      if ((kv.first == "ExposureTime") ||
-          (kv.first == "ExposureTimeRatio"))
+      if ((kv.first == "imager_001/ExposureTime") ||
+          (kv.first == "imager_001/ExposureTimeRatio") ||
+          (kv.first == "imager_001/Channel"))
         {
           member =
             std::make_pair(kv.first, xmlrpc_c::value_int(std::stoi(kv.second)));

--- a/modules/camera/test/o3d3xx-camera-tests.cpp
+++ b/modules/camera/test/o3d3xx-camera-tests.cpp
@@ -394,7 +394,7 @@ TEST(Camera_Tests, DISABLED_TemporaryParameters)
 {
   std::unordered_map<std::string, std::string> params =
     {
-      {"ExposureTime", "6000"}
+      {"imager_001/ExposureTime", "6000"}
     };
 
   o3d3xx::Camera::Ptr cam = std::make_shared<o3d3xx::Camera>();
@@ -402,8 +402,8 @@ TEST(Camera_Tests, DISABLED_TemporaryParameters)
 
   cam->SetTemporaryApplicationParameters(params);
 
-  params["ExposureTime"] = "5000";
-  params["ExposureTimeRatio"] = "40";
+  params["imager_001/ExposureTime"] = "5000";
+  params["imager_001/ExposureTimeRatio"] = "40";
 
   cam->SetTemporaryApplicationParameters(params);
 }

--- a/modules/examples/ex-exposure_times.cpp
+++ b/modules/examples/ex-exposure_times.cpp
@@ -88,8 +88,8 @@ int main(int argc, const char **argv)
   // on-the-fly. We seed it with data consistent with our config above
   std::unordered_map<std::string, std::string> params =
     {
-      {"ExposureTime", "5000"},
-      {"ExposureTimeRatio", "40"}
+      {"imager_001/ExposureTime", "5000"},
+      {"imager_001/ExposureTimeRatio", "40"}
     };
 
   // create a session with the camera so we can modulate the exposure times


### PR DESCRIPTION
I just noted that a customer mentioned some time ago that he had to patch the `Camera::SetTemporaryApplicationParameters()` implementation in order to work with the latest camera firmware that supports the feature. On that occasion, I also added the "imager_001/Channel" parameter which is now also supported on the camera.