### PR TITLE
added an example how to alter the IPv4 Address

### DIFF
--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -114,3 +114,8 @@ target_link_libraries(ex-exposure_times
                       ${PCL_COMMON_LIBRARIES}
                       ${OpenCV_LIBRARIES}
                       )
+add_executable(ex-change_ip ex-change_ip.cpp)
+target_link_libraries(ex-change_ip
+                      ${O3D3XX_CAMERA_LIBRARIES}
+                      ${LIB_boost_system}
+                      )

--- a/modules/examples/README.md
+++ b/modules/examples/README.md
@@ -71,3 +71,6 @@ What is included?
 * [ex-exposure_times](ex-exposure_times.cpp) Shows how to change imager
   exposure times on the fly while streaming in pixel data and validating the
   setting of the exposure times registered to the frame data.
+
+* [ex-change_ip](ex-change_ip.cpp) Shows how to change the IPv4 address of
+  the camera.

--- a/modules/examples/ex-change_ip.cpp
+++ b/modules/examples/ex-change_ip.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 ifm syntron gmbh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// ex-change_ip.cpp
+//
+// Change the IPv4 address of the camera
+//
+
+#include <iostream>
+#include <memory>
+#include "o3d3xx_camera.h"
+#include "o3d3xx_framegrabber.h"
+
+int main(int argc, const char **argv)
+{
+    o3d3xx::Logging::Init();
+
+    o3d3xx::Camera::Ptr cam = std::make_shared<o3d3xx::Camera>();
+    cam->RequestSession();
+    cam->SetOperatingMode(o3d3xx::Camera::operating_mode::EDIT);
+
+    o3d3xx::NetConfig::Ptr net = cam->GetNetConfig();
+    bool has_changed = true;
+    net->SetStaticIPv4Address("192.168.0.70");
+    cam->SetNetConfig(net.get(), &has_changed);
+    cam->SaveNet();
+
+    return 0;
+}


### PR DESCRIPTION
This example demonstrates how change the IPv4 address of the camera.
It might come handy when you have several cameras and want to change
their IP.

Signed-off-by: Christian Ege <christian.ege@ifm.com>