### PR TITLE
Add PCICClient example to modules/examples

### DIFF
--- a/cmake/modules/Findo3d3xx_pcicclient.cmake
+++ b/cmake/modules/Findo3d3xx_pcicclient.cmake
@@ -1,0 +1,72 @@
+find_path(O3D3XX_PCICCLIENT_INCLUDE_DIRS
+  NAMES o3d3xx_pcicclient.h
+  PATHS /opt/libo3d3xx/include /usr/include /usr/local/include /usr/local/libo3d3xx/include
+  NO_DEFAULT_PATH
+  DOC "o3d3xx_pcicclient Include directory"
+  )
+
+find_library(O3D3XX_PCICCLIENT_LIBRARIES
+  NAMES o3d3xx_pcicclient libo3d3xx_pcicclient_static.a
+  PATHS /opt/libo3d3xx/lib /usr/lib /usr/local/lib /usr/local/libo3d3xx/lib
+  NO_DEFAULT_PATH
+  DOC "o3d3xx_pcicclient shared object file"
+  )
+
+get_filename_component(
+  O3D3XX_PCICCLIENT_LIBRARY_DIR
+  ${O3D3XX_PCICCLIENT_LIBRARIES}
+  DIRECTORY
+  )
+
+# kind of hacky
+include(
+ "${O3D3XX_PCICCLIENT_LIBRARY_DIR}/o3d3xx_pcicclient/o3d3xx_pcicclient-config-version.cmake"
+ )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(O3D3XX_PCICCLIENT
+  FOUND_VAR O3D3XX_PCICCLIENT_FOUND
+  REQUIRED_VARS O3D3XX_PCICCLIENT_LIBRARIES
+                O3D3XX_PCICCLIENT_INCLUDE_DIRS
+  VERSION_VAR O3D3XX_PCICCLIENT_VERSION
+  )
+
+set(_version_major ${o3d3xx_pcicclient_FIND_VERSION_MAJOR})
+set(_version_minor ${o3d3xx_pcicclient_FIND_VERSION_MINOR})
+set(_version_patch ${o3d3xx_pcicclient_FIND_VERSION_PATCH})
+set(O3D3XX_PCICCLIENT_FIND_VERSION
+    "${_version_major}.${_version_minor}.${_version_patch}")
+
+if("${O3D3XX_PCICCLIENT_VERSION}" VERSION_LESS "${O3D3XX_PCICCLIENT_FIND_VERSION}")
+  set(O3D3XX_PCICCLIENT_VERSION_COMPATIBLE FALSE)
+  set(O3D3XX_PCICCLIENT_VERSION_EXACT FALSE)
+else()
+  set(O3D3XX_PCICCLIENT_VERSION_COMPATIBLE TRUE)
+  if ("${O3D3XX_PCICCLIENT_VERSION}" VERSION_EQUAL "${O3D3XX_PCICCLIENT_FIND_VERSION}")
+    set(O3D3XX_PCICCLIENT_VERSION_EXACT TRUE)
+  else()
+    set(O3D3XX_PCICCLIENT_VERSION_EXACT FALSE)
+  endif()
+endif()
+
+if(${o3d3xx_pcicclient_FIND_VERSION_EXACT})
+  if(NOT ${O3D3XX_PCICCLIENT_VERSION_EXACT})
+    message(FATAL_ERROR
+     "o3d3xx_pcicclient: ${o3d3xx_pcicclient_FIND_VERSION} != ${O3D3XX_PCICCLIENT_VERSION}")
+  endif()
+endif()
+
+if(NOT ${O3D3XX_PCICCLIENT_VERSION_COMPATIBLE})
+  message(FATAL_ERROR
+   "o3d3xx_pcicclient: ${O3D3XX_PCICCLIENT_VERSION} is incompatible with ${o3d3xx_pcicclient_FIND_VERSION}")
+endif()
+
+mark_as_advanced(
+  O3D3XX_PCICCLIENT_LIBRARIES
+  O3D3XX_PCICCLIENT_INCLUDE_DIRS
+  )
+
+# get_cmake_property(_variableNames VARIABLES)
+# foreach (_variableName ${_variableNames})
+#    message(STATUS "${_variableName}=${${_variableName}}")
+# endforeach()

--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ include(o3d3xx_version)
 find_package(o3d3xx_camera ${O3D3XX_VERSION_STRING} EXACT REQUIRED)
 find_package(o3d3xx_framegrabber ${O3D3XX_VERSION_STRING} EXACT REQUIRED)
 find_package(o3d3xx_image ${O3D3XX_VERSION_STRING} EXACT REQUIRED)
+find_package(o3d3xx_pcicclient ${O3D3XX_VERSION_STRING} EXACT REQUIRED)
 find_package(PCL 1.7.1 REQUIRED COMPONENTS common io)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
@@ -117,5 +118,11 @@ target_link_libraries(ex-exposure_times
 add_executable(ex-change_ip ex-change_ip.cpp)
 target_link_libraries(ex-change_ip
                       ${O3D3XX_CAMERA_LIBRARIES}
+                      ${LIB_boost_system}
+                      )
+add_executable(ex-pcicclient_set_io ex-pcicclient_set_io.cpp)
+target_link_libraries(ex-pcicclient_set_io
+                      ${O3D3XX_CAMERA_LIBRARIES}
+		      ${O3D3XX_PCICCLIENT_LIBRARIES}
                       ${LIB_boost_system}
                       )

--- a/modules/examples/README.md
+++ b/modules/examples/README.md
@@ -74,3 +74,6 @@ What is included?
 
 * [ex-change_ip](ex-change_ip.cpp) Shows how to change the IPv4 address of
   the camera.
+
+* [ex-pcicclient_set_io](ex-pcicclient_set_io.cpp) Shows how to set digital IOs
+  of the camera.

--- a/modules/examples/ex-pcicclient_set_io.cpp
+++ b/modules/examples/ex-pcicclient_set_io.cpp
@@ -1,0 +1,84 @@
+// -*- c++ -*-
+/*
+ * Copyright (C) 2017 Kuhn & Völkel GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// ex-pcicclient_set_io.cpp
+//
+// Shows how to use the PCICClient module to control the IOs state
+// of the camera.
+//
+
+#include <iostream>
+#include <string>
+#include <thread>
+#include <o3d3xx_camera.h>
+#include <o3d3xx_pcicclient.h>
+
+// Camera configuration string:
+// * Create and activate application with index 1
+// * Set LogicGraph to control IOs state via PCIC interface
+const char *config = R"CONFIG(
+{
+    "o3d3xx":
+    {
+        "Device":
+        {
+            "ActiveApplication": "1"
+        },
+        "Apps":
+        [
+            {
+                "Name": "PCICClient Example",
+                "Description": "Manipulates digital IOs",
+                "Index" : "1",
+                "LogicGraph": "{\n    \"IOMap\": {\n        \"OUT1\": \"PCIC_OUT\",\n        \"OUT2\": \"PCIC_OUT\"\n    },\n    \"blocks\": {\n        \"B00001\": {\n            \"pos\": {\n                \"x\": 262,\n                \"y\": 132\n            },\n            \"properties\": {\n            },\n            \"type\": \"PIN_EVENT_PCIC_O_CMD\"\n        },\n        \"B00003\": {\n            \"pos\": {\n                \"x\": 600,\n                \"y\": 75\n            },\n            \"properties\": {\n                \"pulse_duration\": 0\n            },\n            \"type\": \"DIGITAL_OUT1\"\n        },\n        \"B00005\": {\n            \"pos\": {\n                \"x\": 600,\n                \"y\": 200\n            },\n            \"properties\": {\n                \"pulse_duration\": 0\n            },\n            \"type\": \"DIGITAL_OUT2\"\n        }\n    },\n    \"connectors\": {\n        \"C00000\": {\n            \"dst\": \"B00003\",\n            \"dstEP\": 0,\n            \"src\": \"B00001\",\n            \"srcEP\": 0\n        },\n        \"C00001\": {\n            \"dst\": \"B00005\",\n            \"dstEP\": 0,\n            \"src\": \"B00001\",\n            \"srcEP\": 0\n        }\n    }\n}\n"
+            }
+        ]
+    }
+}
+)CONFIG";
+
+
+int main(int argc, char** argv)
+{
+  // Create camera
+  o3d3xx::Camera::Ptr cam = std::make_shared<o3d3xx::Camera>();
+
+  // Configure camera to allow user defined IO state
+  cam->FromJSON(config);
+
+  // Create pcic interface
+  o3d3xx::PCICClient::Ptr pcic = std::make_shared<o3d3xx::PCICClient>(cam);
+
+  // Start setting IOs (and led flashing) for ~10 seconds
+  pcic->Call("o010"); // OUT1 off
+  pcic->Call("o020"); // OUT2 off
+  for(int i = 0; i < 25; ++i)
+    {
+      std::cout << "Pass " << (i+1) << "/" << 25 << std::endl;
+      pcic->Call("o011"); // OUT1 on
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      pcic->Call("o021"); // OUT2 on
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      pcic->Call("o010"); // OUT1 off
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      pcic->Call("o020"); // OUT2 off
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+  return 0;
+}

--- a/modules/examples/ex-pcicclient_set_io.cpp
+++ b/modules/examples/ex-pcicclient_set_io.cpp
@@ -64,20 +64,30 @@ int main(int argc, char** argv)
   // Create pcic interface
   o3d3xx::PCICClient::Ptr pcic = std::make_shared<o3d3xx::PCICClient>(cam);
 
-  // Start setting IOs (and led flashing) for ~10 seconds
+  // Start setting IOs (and led flashing)
   pcic->Call("o010"); // OUT1 off
   pcic->Call("o020"); // OUT2 off
-  for(int i = 0; i < 25; ++i)
+  for(int i = 0; i < 10; ++i)
     {
       std::cout << "Pass " << (i+1) << "/" << 25 << std::endl;
+
       pcic->Call("o011"); // OUT1 on
+      std::cout << "State: " << pcic->Call("O01?") << " " << pcic->Call("O02?") << std::endl;
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
       pcic->Call("o021"); // OUT2 on
+      std::cout << "State: " << pcic->Call("O01?") << " " << pcic->Call("O02?") << std::endl;
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
       pcic->Call("o010"); // OUT1 off
+      std::cout << "State: " << pcic->Call("O01?") << " " << pcic->Call("O02?") << std::endl;
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
       pcic->Call("o020"); // OUT2 off
+      std::cout << "State: " << pcic->Call("O01?") << " " << pcic->Call("O02?") << std::endl;
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      std::cout << std::endl;
     }
 
   return 0;

--- a/modules/examples/ex-pcicclient_set_io.cpp
+++ b/modules/examples/ex-pcicclient_set_io.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
   pcic->Call("o020"); // OUT2 off
   for(int i = 0; i < 10; ++i)
     {
-      std::cout << "Pass " << (i+1) << "/" << 25 << std::endl;
+      std::cout << "Pass " << (i+1) << "/" << 10 << std::endl;
 
       pcic->Call("o011"); // OUT1 on
       std::cout << "State: " << pcic->Call("O01?") << " " << pcic->Call("O02?") << std::endl;


### PR DESCRIPTION
This example creates/configures an application on the camera for programmatically setting the IO states of the camera and demonstrates the usage of the PCICClient altering/querying the IO states - as discussed with @graugans and @cfreundl .