### PR TITLE
Integrate illu temp

### DIFF
--- a/modules/framegrabber/src/bin/o3d3xx-schema.cpp
+++ b/modules/framegrabber/src/bin/o3d3xx-schema.cpp
@@ -75,7 +75,9 @@ int main(int argc, const char** argv)
                     << '\t' << "IMG_UVEC: "
                     << (int) o3d3xx::IMG_UVEC << std::endl
                     << '\t' << "EXP_TIME: "
-                    << (int) o3d3xx::EXP_TIME << std::endl;
+                    << (int) o3d3xx::EXP_TIME << std::endl
+	            << '\t' << "ILLU_TEMP: "
+		    << (int) o3d3xx::ILLU_TEMP << std::endl;
           return 0;
         }
 

--- a/modules/framegrabber/src/libo3d3xx_framegrabber/pcic_schema.cpp
+++ b/modules/framegrabber/src/libo3d3xx_framegrabber/pcic_schema.cpp
@@ -122,6 +122,17 @@ o3d3xx::make_pcic_schema(std::uint16_t mask)
            })";
     }
 
+  if((mask & o3d3xx::ILLU_TEMP) == o3d3xx::ILLU_TEMP)
+    {
+      schema +=
+	R"(,
+             {"type":"string", "id":"temp_illu", "value":"temp_illu"},
+             {
+              "type":"float32", "id":"temp_illu",
+              "format":{"dataencoding":"binary", "order":"little"}
+             })";
+    }
+
   // other invariants
   schema +=
   R"(,
@@ -166,6 +177,10 @@ o3d3xx::schema_mask_from_string(const std::string& in)
         {
           mask |= o3d3xx::EXP_TIME;
         }
+      else if (part == "ILLU_TEMP")
+	{
+	  mask |= o3d3xx::ILLU_TEMP;
+	}
     }
 
   return mask;

--- a/modules/image/include/o3d3xx_image/image.h
+++ b/modules/image/include/o3d3xx_image/image.h
@@ -162,6 +162,14 @@ namespace o3d3xx
     std::vector<std::uint32_t> ExposureTimes();
 
     /**
+     * Returns the temperature of the illumination unit.
+     *
+     * NOTE: To get the temperature of the illumination unit to the frame, you
+     * need to make sure your current pcic schema asks for it.
+     */
+    float IlluTemp();
+
+    /**
      * Synchronizes the parsed out image data with the internally wrapped byte
      * buffer.
      */
@@ -177,6 +185,11 @@ namespace o3d3xx
      * The exposure time data
      */
     std::vector<std::uint32_t> exposure_times_;
+
+    /**
+     * The temperature of the illumination unit
+     */
+    float illu_temp_;
 
     /**
      * Point cloud used to hold the cartesian xyz and amplitude data (intensity

--- a/modules/image/test/o3d3xx-image-tests.cpp
+++ b/modules/image/test/o3d3xx-image-tests.cpp
@@ -804,3 +804,47 @@ TEST(ImageBuffers_Tests, DISABLED_ExposureTimes)
   EXPECT_EQ(exposure_times[2], 0);
 
 }
+
+TEST(ImageBuffers_Tests, DISABLED_IlluTemp)
+{
+  std::string json =
+    R"(
+        {
+          "o3d3xx":
+          {
+            "Device":
+            {
+              "ActiveApplication": "1"
+            },
+            "Apps":
+            [
+              {
+                "TriggerMode": "1",
+                "Index": "1",
+                "Imager":
+                {
+                    "ExposureTime": "5000",
+                    "ExposureTimeList": "125;5000",
+                    "ExposureTimeRatio": "40",
+                    "Type":"under5m_moderate"
+                }
+              }
+           ]
+          }
+        }
+      )";
+
+  o3d3xx::Camera::Ptr cam = std::make_shared<o3d3xx::Camera>();
+  cam->FromJSON(json);
+
+  o3d3xx::ImageBuffer::Ptr img = std::make_shared<o3d3xx::ImageBuffer>();
+  o3d3xx::FrameGrabber::Ptr fg =
+    std::make_shared<o3d3xx::FrameGrabber>(
+      cam, o3d3xx::DEFAULT_SCHEMA_MASK|o3d3xx::ILLU_TEMP);
+
+  EXPECT_TRUE(fg->WaitForFrame(img.get(), 1000));
+  float illu_temp = img->IlluTemp();
+
+  EXPECT_GT(illu_temp, 10);
+  EXPECT_LT(illu_temp, 90);
+}


### PR DESCRIPTION
Integrates illu temp as discussed with @cfreundl and an accompanying test case.

I needed to refactor the part inside o3d3xx::ImageBuffer::Organize() for parsing exposure times.
I tried to create a review request (@tpanzarella and @cfreundl ) for the two pull requests today - but I guess I'm not allowed according https://help.github.com/articles/requesting-a-pull-request-review/ -> ("owner or collaborator")