### PR TITLE
Added an example to check if camera has booted

### DIFF
--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(PCL 1.7.1 REQUIRED COMPONENTS common io)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 
+
 find_library(LIB_boost_system NAMES boost_system)
 
 # Fix this: https://bugs.launchpad.net/ubuntu/+source/vtk6/+bug/1573234
@@ -143,3 +144,7 @@ target_link_libraries(ex-fast_app_switch
                       ${OpenCV_LIBRARIES}
                       ${LIB_boost_system}
                       )
+add_executable(ex-oem_is_booted ex-oem_is_booted.cpp)
+target_link_libraries(ex-oem_is_booted
+                      ${O3D3XX_CAMERA_LIBRARIES}
+)

--- a/modules/examples/README.md
+++ b/modules/examples/README.md
@@ -85,3 +85,6 @@ What is included?
   different applications on the camera over PCIC. For convenience is prints out
   some (rough) timing metrics. NOTE: This assumes you have a camera capable of
   running the 100k pixel imager.
+
+* [ex-oem_is_booted](ex-oem_is_booted.cpp) Shows how to check if the camera
+  has completly booted.

--- a/modules/examples/ex-oem_is_booted.cpp
+++ b/modules/examples/ex-oem_is_booted.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 ifm syntron gmbh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// ex-oem_is_booted.cpp
+//
+// Check if the camera is completly booted.
+// What is mostly useful for an on camera application.
+//
+
+#include <iostream>
+#include <memory>
+#include <chrono>
+#include <thread>
+#include <algorithm>
+#include "o3d3xx_camera.h"
+
+bool wait_for_camera(o3d3xx::Camera::Ptr cam, int seconds)
+{
+    seconds = std::max(seconds,1);
+    std::unordered_map<std::string, std::string> sw_version = cam->GetSWVersion();
+    while(sw_version["Algorithm_Version"].empty() && (seconds > 0))
+    {
+        std::this_thread::sleep_for (std::chrono::seconds(1));
+        seconds--;
+    }
+    return (seconds > 0);
+}
+
+int main(int argc, const char **argv)
+{
+    const auto seconds_to_wait = 20;
+    o3d3xx::Logging::Init();
+    o3d3xx::Camera::Ptr cam = o3d3xx::Camera::Ptr(new o3d3xx::Camera());
+
+    std::cout << "Waiting for the camera to operate: ";
+    if(wait_for_camera(cam, seconds_to_wait))
+    {
+        std::cout << "[done]" << std::endl;
+    }
+    else
+    {
+        std::cout << "[TIMEOUT]" << std::endl;
+    }
+}


### PR DESCRIPTION
Due to the fact on the camera there are a few processes are started
it is recommended to wait for all services correctly started.
We recognize a ready camera by all Software version information
correctly filled.

Signed-off-by: Christian Ege <christian.ege@ifm.com>