### PR TITLE
Description about the PCIC asynchronous error IDs

### DIFF
--- a/doc/pcic_async_errors.md
+++ b/doc/pcic_async_errors.md
@@ -1,0 +1,36 @@
+|Code-ID |Error|
+|--------|-----|
+|100000001| Maximum number of connections exceeded |
+|100000002| Internal failure during a D-Bus call|
+|100000003| Unspecified internal error|
+|100000004| Generic invalid parameter|
+|100000005| Invalid command|
+|100001000| Application configuration does not allow PCIC trigger|
+|100001001| Video mode does not allow PCIC trigger|
+|100001002| There is no application configured|
+|100001003| Invalid image id in I? Command|
+|100001004| Invalid pin id in o/O? Command|
+|100001005| Invalid pin configuration in o/O? Command |
+|100001006| Invalid conversion type selected|
+|100001007| No trigger was run yet|
+|110001001| Boot timeout|
+|110001002| Fatal software error|
+|110001003| Unknown hardware|
+|100001004| Invalid pin id in o/O? Command|
+|100001005| Invalid pin configuration in o/O? Command|
+|110001006| Trigger overrun|
+|110002000| Short circuit on Ready for Trigger|
+|110002001| Short circuit on OUT1|
+|110002002| Short circuit on OUT2|
+|110002003| Reverse feeding|
+|110003000| Vled over voltage|
+|110003001| Vled under voltage|
+|110003002| Vmod over voltage|
+|110003003| Vmod under voltage|
+|110003004| Mainboard over voltage|
+|110003005| Mainboard under voltage|
+|110003006| Supply over voltage|
+|110003007| Supply under voltage|
+|110003008| VFEMon alarm|
+|110003009| PMIC supply alarm|
+|110004000| Illumination over temperature|


### PR DESCRIPTION
Those IDs are send by PCIC on ticket number ``0001``. The
pcicclient module can be used to receive them.

Signed-off-by: Christian Ege <k4230r6@gmail.com>