### PR TITLE
Fixed a race condition with the wait for OEM bootet

### DIFF
--- a/modules/examples/ex-oem_is_booted.cpp
+++ b/modules/examples/ex-oem_is_booted.cpp
@@ -33,8 +33,8 @@ bool wait_for_camera(o3d3xx::Camera::Ptr cam, int seconds)
 {
     seconds = std::max(seconds,1);
     std::unordered_map<std::string, std::string> sw_version;
-    auto start = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double> duration;
+    auto start = std::chrono::steady_clock::now();
+    std::chrono::duration<double> duration(0);
     bool isValid=false;
 
     while( (!isValid) && (duration < std::chrono::seconds( seconds ) ) )
@@ -47,7 +47,7 @@ bool wait_for_camera(o3d3xx::Camera::Ptr cam, int seconds)
         {
             // Not able to get SW version
         }
-        duration = std::chrono::high_resolution_clock::now() - start;
+        duration = std::chrono::steady_clock::now() - start;
 
         if(sw_version["Algorithm_Version"].empty())
             std::this_thread::sleep_for (std::chrono::seconds(1));


### PR DESCRIPTION
When using a NTP server it could happen that there has
a time synchronization taken place right in the time
when we are in the loop to wait for the camera being
booted. The loop will be left because the timeout was
triggered. By using a monotonic clock we ensure that the
jump in time will not influence us. This does not solve
issue #122 which deals with ``WaitForFrame`` being not
error proof against time jumps.

This also fixes an initialization issue with the duration
variable.

Signed-off-by: Christian Ege <christian.ege@ifm.com>